### PR TITLE
Remove TODO about using the version of ndk system library

### DIFF
--- a/services/ml/BUILD.gn
+++ b/services/ml/BUILD.gn
@@ -56,9 +56,6 @@ source_set("lib") {
       assert(false, "Need android neuralnetworks support for your target arch.")
     }
     lib_dirs = [
-      # TODO(junwei.fu): https://github.com/otcshare/webml-polyfill/issues/83
-      # ${android_sdk_platform_version} current is 28 the library in android ndk
-      # isn't ported.
       "${android_ndk_root}/platforms/android-27/${libdir}",
     ]
 


### PR DESCRIPTION
There are no better variable to get the latest version of ndk system library, we need to update manually when ndk-28 is available.

Fix  https://github.com/otcshare/webml-polyfill/issues/83