### PR TITLE
Bug fixes for error handling

### DIFF
--- a/services/ml/compilation_impl_mac.mm
+++ b/services/ml/compilation_impl_mac.mm
@@ -1066,7 +1066,7 @@ namespace ml {
     auto impl =
         std::make_unique<ExecutionImplMac>(this, std::move(memory_handle));
     if (!impl->IsValid()) {
-      std::move(callback).Run(mojom::BAD_DATA, std::move(init_params));
+      std::move(callback).Run(mojom::BAD_DATA, nullptr);
       return;
     }
     mojom::ExecutionPtrInfo ptr_info;

--- a/services/ml/execution_impl_mac.mm
+++ b/services/ml/execution_impl_mac.mm
@@ -480,7 +480,7 @@ void ExecutionImplMac::StartCompute(StartComputeCallback callback) {
             if (!dst_img) {
               if (tmp_mpsimage_cache.find(operation_output_idx) ==
                   tmp_mpsimage_cache.end()) {
-                MPSImageDescriptor* descriptor = CreateMPSImageDescriptor(operation_input);
+                MPSImageDescriptor* descriptor = CreateMPSImageDescriptor(operation_output);
                 if (!descriptor) {
                   success = false;
                   break;


### PR DESCRIPTION
Fixes:
- Used the wrong parameter to create MPSImage descriptor.
- Crashed because no execution is passed when the construction of
execution is incomplete.