### PR TITLE
Mac: Fix 10.14 build failure

### DIFF
--- a/chrome/browser/app_controller_mac.mm
+++ b/chrome/browser/app_controller_mac.mm
@@ -1642,7 +1642,13 @@ static base::mac::ScopedObjCClassSwizzler* g_swizzle_imk_input_session;
 
 - (BOOL)application:(NSApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
+#if !defined(MAC_OS_X_VERSION_10_14) || \
+    MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_14
       restorationHandler:(void (^)(NSArray*))restorationHandler
+#else
+      restorationHandler:
+          (void (^)(NSArray<id<NSUserActivityRestoring>>*))restorationHandler
+#endif
     API_AVAILABLE(macos(10.10)) {
   if (![userActivity.activityType
           isEqualToString:NSUserActivityTypeBrowsingWeb]) {


### PR DESCRIPTION
macOS 10.14 changed the method signature of a block parameter to
application:continueUserActivity:restorationHandler: by introducing a
lightweight generic.

Since the parameter is unused and the protocol specified by the new
generic is 10.14+, this change ignores the mismatched parameter.

Bug: 887214
Change-Id: I4a111cdb69ac4fcc22a78448b3efb5bc7c0536e9
Reviewed-on: https://chromium-review.googlesource.com/1246322
Reviewed-by: Nico Weber <thakis@chromium.org>
Commit-Queue: Leonard Grey <lgrey@chromium.org>
Cr-Commit-Position: refs/heads/master@{#594365}