### PR TITLE
Fix crash issue for bnns

### DIFF
--- a/services/ml/compilation_impl_mac.mm
+++ b/services/ml/compilation_impl_mac.mm
@@ -157,8 +157,7 @@ void CompilationImplMac::CompileModelWithBNNS(FinishCallback callback) {
       success = CompileConcatenationBNNS(operation, values_, memory_,
                                          i == 0 ? true : false);
     } else if (type == mojom::ADD || type == mojom::MUL) {
-      success =
-          CompileCompileArithmeticBNNS(operation, values_, memory_, operands_);
+      success = CompileArithmeticBNNS(operation, values_, memory_, operands_);
     } else if (type == mojom::FULLY_CONNECTED) {
       success =
           CompileFullyConnectedBNNS(operation, values_, memory_, operands_);

--- a/services/ml/compilation_impl_mac_bnns.h
+++ b/services/ml/compilation_impl_mac_bnns.h
@@ -17,10 +17,10 @@ API_AVAILABLE(macosx(10.13))
 bool CompileResizeBilinearBNNS(OperationMac& operation);
 
 API_AVAILABLE(macosx(10.13))
-bool CompileCompileArithmeticBNNS(OperationMac&,
-                                  const std::map<uint32_t, ValueInfo>& values,
-                                  const std::unique_ptr<int8_t[]>& memory,
-                                  const std::vector<OperandMac>& operands);
+bool CompileArithmeticBNNS(OperationMac&,
+                           const std::map<uint32_t, ValueInfo>& values,
+                           const std::unique_ptr<int8_t[]>& memory,
+                           const std::vector<OperandMac>& operands);
 
 API_AVAILABLE(macosx(10.13))
 bool CompileConv2DBNNS(OperationMac&,

--- a/services/ml/compilation_impl_mac_bnns.mm
+++ b/services/ml/compilation_impl_mac_bnns.mm
@@ -76,10 +76,10 @@ bool CompileResizeBilinearBNNS(OperationMac& operation) {
 }
 
 API_AVAILABLE(macosx(10.13))
-bool CompileCompileArithmeticBNNS(OperationMac& operation,
-                                  const std::map<uint32_t, ValueInfo>& values,
-                                  const std::unique_ptr<int8_t[]>& memory,
-                                  const std::vector<OperandMac>& operands) {
+bool CompileArithmeticBNNS(OperationMac& operation,
+                           const std::map<uint32_t, ValueInfo>& values,
+                           const std::unique_ptr<int8_t[]>& memory,
+                           const std::vector<OperandMac>& operands) {
   DLOG(INFO) << "CompilationImplMac::CompileArithmetic";
   DLOG_IF(FATAL, operation.type != mojom::ADD && operation.type != mojom::MUL);
 
@@ -97,10 +97,13 @@ bool CompileCompileArithmeticBNNS(OperationMac& operation,
     return false;
   }
 
-  uint32_t extend_input_idx =
-      values.find(inputs[0]) == values.end() ? inputs[1] : inputs[0];
-  operation.extend_input.push_back(reinterpret_cast<float*>(
-      memory.get() + values.at(extend_input_idx).offset));
+  for (size_t i = 0; i < 2; i++) {
+    uint32_t extend_input_idx = inputs[i];
+    if (values.find(extend_input_idx) != values.end()) {
+      operation.extend_input.push_back(reinterpret_cast<float*>(
+          memory.get() + values.at(extend_input_idx).offset));
+    }
+  }
 
   const int32_t fuse_code = getScalarInt32(values, inputs[2], memory.get());
   DLOG(INFO) << "FUSE_CODE:  " << fuse_code;


### PR DESCRIPTION
Fix [intel/webml-polyfill#550](https://github.com/intel/webml-polyfill/issues/550).

- ResNet50 V1(onnx) worked.
- ResNet50 V2(onnx) worked.
- Inception Resnet v2(TFlite) worked.

@fujunwei , please help to review.