### PR TITLE
[DML] Reset command list and allocator for exection

### DIFF
--- a/services/ml/compilation_delegate_dml.cc
+++ b/services/ml/compilation_delegate_dml.cc
@@ -377,6 +377,9 @@ HRESULT InitializeOperators(scoped_refptr<CompiledModelDML> dml,
 
   // Free unused resources.
   FreeUnusedResources(dml.get(), init_buffer_array, size);
+  // Reset command list and allocator those will be setted in execution phase.
+  dml->command_allocator_->Reset();
+  dml->command_list_->Reset(dml->command_allocator_.Get(), nullptr);
 
   return S_OK;
 }

--- a/services/ml/execution_impl_dml.cc
+++ b/services/ml/execution_impl_dml.cc
@@ -62,12 +62,6 @@ void ExecutionImplDML::StartCompute(StartComputeCallback callback) {
       return;
     }
   }
-  hr = CloseExecuteResetWait(dml_->d3d12_device_, dml_->command_queue_,
-                             dml_->command_allocator_, dml_->command_list_);
-  if (FAILED(hr)) {
-    LOG(ERROR) << "Failed executing command list for compiled operators.";
-    return;
-  }
 
   hr = ReadResultBack(memory_offset);
   if (FAILED(hr)) {
@@ -117,6 +111,7 @@ HRESULT ExecutionImplDML::ReadResultBack(uint32_t memory_offset) {
                                       output_resource.Get());
   }
 
+  // Reset command list only, keep the command in allocator.
   CloseExecuteResetWait(dml_->d3d12_device_, dml_->command_queue_,
                         dml_->command_allocator_, dml_->command_list_);
 


### PR DESCRIPTION


float32 | float32 +Reset CommandList | float16 | float16 + Reset CommandList | WebGL | clDNN
-- | -- | -- | -- | -- | --
22 | 18 | 24 | 17 | 78 | 11
21 | 19 | 21 | 18 | 121 | 12
79 | 75 | 66 | 65 | 356 | 61
149 | 149 | 122 | 116 | 552 | 121


