### PR TITLE
[DML] Use half precision by default

### DIFF
--- a/services/ml/compilation_delegate_dml.cc
+++ b/services/ml/compilation_delegate_dml.cc
@@ -491,7 +491,7 @@ CompilationDelegateDML::CompilationDelegateDML(
   if (SUCCEEDED(hr)) {
     DLOG(INFO) << "Support float16 data type " << g_support_f16;
   }
-  g_support_f16 = false;//support_f16.IsSupported;
+  g_support_f16 = support_f16.IsSupported;
 }
 
 CompilationDelegateDML::~CompilationDelegateDML() = default;


### PR DESCRIPTION
Fix https://github.com/intel/webml-polyfill/issues/908, https://github.com/intel/webml-polyfill/issues/882

Our test cases has updated float16 precision align with [android NN CTS](https://android.googlesource.com/platform/frameworks/ml/+/master/nn/tools/test_generator/include/TestHarness.h#331).

But there are some large value test cases can't be passed because overflow the max of  float16 (65504).