### PR TITLE
[MPS] Fixing below crashed issue

### DIFF
--- a/services/ml/compilation_impl_mac.mm
+++ b/services/ml/compilation_impl_mac.mm
@@ -240,8 +240,8 @@ void CompilationImplMac::CompileModelWithMPS(FinishCallback callback) {
     } else if (type == mojom::RESHAPE) {
       success = CompileReshape(operations_, operation);
     } else if (type == mojom::CONCATENATION) {
-      success = CompileConcatenation(mps_image_nodes_, operations_, operation,
-                                     values_, memory_, operands_);
+      success = CompileConcatenation(mps_image_nodes_, operations_, constants_,
+                                     operation, values_, memory_, operands_);
       DLOG(ERROR) << "CONCATENATION is not supported";
     } else if (type == mojom::ADD || type == mojom::MUL) {
       success = CompileArithmetic(mps_image_nodes_, operation, operands_,

--- a/services/ml/compilation_impl_mac_mps.h
+++ b/services/ml/compilation_impl_mac_mps.h
@@ -45,6 +45,7 @@ bool CompileReshape(std::vector<OperationMac>& operations,
 API_AVAILABLE(macosx(10.13))
 bool CompileConcatenation(std::map<uint32_t, MPSNNImageNode*>& image_nodes,
                           std::vector<OperationMac>& operations,
+                          std::vector<uint32_t>& constants,
                           const OperationMac& concat,
                           const std::map<uint32_t, ValueInfo>& values,
                           const std::unique_ptr<int8_t[]>& memory,

--- a/services/ml/execution_impl_mac_mps.mm
+++ b/services/ml/execution_impl_mac_mps.mm
@@ -216,6 +216,15 @@ void ExecutionImplMacMPS::StartCompute(StartComputeCallback callback) {
               DCHECK(source_image_handles.count == 1);
               uint32_t input_index = [source_image_handles[0].label intValue];
               // Find temporary input images of next graph.
+              // The node has been optimized by last graph that isn't result
+              // node, so the value of temporary_mps_images[input_index] will
+              // be null, the desnet need to be support above 10.15 with
+              // resultImages.
+              // such as graph in desnet: 112->126->122 126->3->0, the 122 node
+              // will be optimized.
+              if (temporary_mps_images.find(input_index) ==
+                  temporary_mps_images.end())
+                break;
               [source_images addObject:temporary_mps_images[input_index]];
             }
           }

--- a/services/ml/model_impl_mac.mm
+++ b/services/ml/model_impl_mac.mm
@@ -58,11 +58,6 @@ int32_t ModelImplMac::SetOperandValue(uint32_t index,
     uint32_t size = length / 4;
     DLOG(INFO) << "    "
                << "buffer(" << size << "): " << VectorToString(value, size);
-  } else if (operand.type == mojom::TENSOR_QUANT8_ASYMM) {
-    const int8_t* value = static_cast<const int8_t*>(buffer);
-    uint32_t size = length;
-    DLOG(INFO) << "    "
-               << "buffer(" << size << "): " << VectorToString(value, size);
   } else if (operand.type == mojom::UINT32) {
     const uint32_t* value = static_cast<const uint32_t*>(buffer);
     uint32_t size = length;


### PR DESCRIPTION
https://github.com/intel/webml-polyfill/issues/717
https://github.com/intel/webml-polyfill/issues/716
the ssdlite_mobilenetv2_face need to be supported above 10.15 with Graph API.
```
initWithDevice: (nonnull id <MTLDevice>) device
                            resultImages: (NSArray <MPSNNImageNode *> * __nonnull) resultImages
                        resultsAreNeeded: (BOOL * __nullable)
```


https://github.com/intel/webml-polyfill/issues/536
The test case still can't be passed because  all images are padded out to a multiple of four feature channels.
That is, if the image is 23 feature channels and one channel  of padding, it takes up 24 feature channels worth of space in the  concatenated result.