### PR TITLE
[Examples][NNAPI] Fix Android version 10.0 bug on NNAPI for intel/webml-polyfill#1060

### DIFF
--- a/services/ml/compilation_impl_android.cc
+++ b/services/ml/compilation_impl_android.cc
@@ -23,8 +23,8 @@ CompilationImplAndroid::CompilationImplAndroid(const ModelImplAndroid* model)
 }
 
 CompilationImplAndroid::~CompilationImplAndroid() {
-  ANeuralNetworksCompilation_free(nn_compilation_);
-  DLOG(INFO) << "ANeuralNetworksCompilation_free";
+  // ANeuralNetworksCompilation_free(nn_compilation_);
+  // The nn_compilation_ will be deleted in execution phase.
 }
 
 void CompilationImplAndroid::Finish(int32_t preference,

--- a/services/ml/execution_impl_android.cc
+++ b/services/ml/execution_impl_android.cc
@@ -20,7 +20,8 @@ ExecutionImplAndroid::ExecutionImplAndroid(
       operations_(compilation->operations_),
       inputs_(compilation->inputs_),
       outputs_(compilation->outputs_),
-      memory_(std::move(memory)) {
+      memory_(std::move(memory)),
+      nn_compilation_(compilation->nn_compilation_) {
   uint32_t total_length = 0;
   inputs_info_.reserve(inputs_.size());
   for (size_t i = 0; i < inputs_.size(); ++i) {
@@ -41,47 +42,44 @@ ExecutionImplAndroid::ExecutionImplAndroid(
         offset, length, memory_->MapAtOffset(length, offset)));
     total_length += length;
   }
+}
 
-  int32_t result = ANeuralNetworksExecution_create(compilation->nn_compilation_,
-                                                   &nn_execution_);
+ExecutionImplAndroid::~ExecutionImplAndroid() {
+  ANeuralNetworksCompilation_free(nn_compilation_);
+  DLOG(INFO) << "ANeuralNetworksCompilation_free";
+}
+
+void ExecutionImplAndroid::StartCompute(StartComputeCallback callback) {
+  DLOG(INFO) << "ExecutionImplAndroid::StartCompute";
+
+  ANeuralNetworksExecution* nn_execution;
+  int32_t result =
+      ANeuralNetworksExecution_create(nn_compilation_, &nn_execution);
   DLOG(INFO) << "ANeuralNetworksExecution_create: " << result;
-
   for (size_t i = 0; i < inputs_info_.size(); ++i) {
     std::unique_ptr<OperandInfo>& info = inputs_info_[i];
     result = ANeuralNetworksExecution_setInput(
-        nn_execution_, i, NULL, static_cast<void*>(info->mapping.get()),
+        nn_execution, i, NULL, static_cast<void*>(info->mapping.get()),
         info->length);
-
     DLOG(INFO) << "ANeuralNetworksExecution_setInput: " << result;
   }
 
   for (size_t i = 0; i < outputs_info_.size(); ++i) {
     std::unique_ptr<OperandInfo>& info = outputs_info_[i];
     result = ANeuralNetworksExecution_setOutput(
-        nn_execution_, i, NULL, static_cast<void*>(info->mapping.get()),
+        nn_execution, i, NULL, static_cast<void*>(info->mapping.get()),
         info->length);
-
     DLOG(INFO) << "ANeuralNetworksExecution_setOutput: " << result;
   }
-}
-
-ExecutionImplAndroid::~ExecutionImplAndroid() {
-  ANeuralNetworksExecution_free(nn_execution_);
-  DLOG(INFO) << "ANeuralNetworksExecution_free";
-}
-
-void ExecutionImplAndroid::StartCompute(StartComputeCallback callback) {
-  DLOG(INFO) << "ExecutionImplAndroid::StartCompute";
 
   ANeuralNetworksEvent* nn_event;
-  int32_t result =
-      ANeuralNetworksExecution_startCompute(nn_execution_, &nn_event);
+  result = ANeuralNetworksExecution_startCompute(nn_execution, &nn_event);
   LOG(INFO) << "ANeuralNetworksExecution_startCompute: " << result;
   result = ANeuralNetworksEvent_wait(nn_event);
   LOG(INFO) << "ANeuralNetworksEvent_wait: " << result;
   ANeuralNetworksEvent_free(nn_event);
 
+  ANeuralNetworksExecution_free(nn_execution);
   std::move(callback).Run(mojom::NOT_ERROR);
 }
-
 }  // namespace ml

--- a/services/ml/execution_impl_android.h
+++ b/services/ml/execution_impl_android.h
@@ -36,12 +36,11 @@ class ExecutionImplAndroid : public mojom::Execution {
   std::vector<uint32_t> inputs_;
   std::vector<uint32_t> outputs_;
 
-  ANeuralNetworksExecution* nn_execution_;
-
   std::vector<std::unique_ptr<OperandInfo>> inputs_info_;
   std::vector<std::unique_ptr<OperandInfo>> outputs_info_;
   mojo::ScopedSharedBufferHandle memory_;
 
+  ANeuralNetworksCompilation* nn_compilation_;
   DISALLOW_COPY_AND_ASSIGN(ExecutionImplAndroid);
 };
 


### PR DESCRIPTION
I have verified these examples, now they can run successfully on Android 10 (Pixel 2 XL). Please help to review. Thanks! @fujunwei @BruceDai 

Manual regression test results:

https://brucedai.github.io/webnnt/test/index-local.html?prefer=sustained
Android 10.0 (Pixel 2 XL): passes: 431 failures: 286 (baseline: "pass": 435, "fail": 282) (four more fails of DEPTHWISE_CONV_2D caused by Android version 10.0)

https://brucedai.github.io/webnnt/test/ops
Android 10.0 (Pixel 2 XL): all pass