### PR TITLE
[INT8][DNNL] Add support for INT8AveragePool

### DIFF
--- a/services/ml/compilation_delegate_dnnl.cc
+++ b/services/ml/compilation_delegate_dnnl.cc
@@ -157,7 +157,7 @@ int32_t CompilationDelegateDnnl::DnnlCompile() {
                type == mojom::ATROUS_DEPTHWISE_CONV_2D) {
       result = AddConvolution(operation, model);
     } else if (type == mojom::AVERAGE_POOL_2D || type == mojom::MAX_POOL_2D) {
-      result = AddPooling(operation);
+      result = AddPooling(operation, model);
     } else if (type == mojom::SOFTMAX) {
       result = AddSoftmax(operation);
     } else if (type == mojom::LOGISTIC) {
@@ -1161,7 +1161,8 @@ int32_t CompilationDelegateDnnl::AddConvolution(
 }
 
 int32_t CompilationDelegateDnnl::AddPooling(
-    const mojom::OperationPtr& operation) {
+    const mojom::OperationPtr& operation,
+    const mojom::ModelInfoPtr& model) {
   PoolingParams params;
   int32_t result = compilation_->GetPoolingParams(operation, params);
   if (result != mojom::NOT_ERROR)
@@ -1181,11 +1182,16 @@ int32_t CompilationDelegateDnnl::AddPooling(
     return mojom::OP_FAILED;
   }
 
+  const std::vector<uint32_t>& outputs = operation->outputs;
+  const mojom::OperandPtr& output = model->operands[outputs[0]];
+  dnnl_data_type_t output_type;
+  GetDataType(output->type, &output_type);
+
   dnnl_memory_desc_t output_md;
   dnnl_dim_t output_dims[4] = {params.output_batch, params.output_channel,
                                params.output_height, params.output_width};
   status = LATE(dnnl_memory_desc_init_by_tag)(&output_md, 4, output_dims,
-                                              dnnl_f32, dnnl_format_tag_any);
+                                              output_type, dnnl_format_tag_any);
   if (status != dnnl_success) {
     LOG(ERROR) << "[DNNL] failed to init output memory descriptor " << status;
     return mojom::OP_FAILED;

--- a/services/ml/compilation_delegate_dnnl.h
+++ b/services/ml/compilation_delegate_dnnl.h
@@ -81,7 +81,7 @@ class CompilationDelegateDnnl : public CompilationDelegate {
   int32_t AddElementwise(const mojom::OperationPtr&);
   int32_t AddConvolution(const mojom::OperationPtr&,
                          const mojom::ModelInfoPtr&);
-  int32_t AddPooling(const mojom::OperationPtr&);
+  int32_t AddPooling(const mojom::OperationPtr&, const mojom::ModelInfoPtr&);
   int32_t AddSoftmax(const mojom::OperationPtr&);
   int32_t AddLogistic(const mojom::OperationPtr&);
   int32_t AddReshape(const mojom::OperationPtr&);


### PR DESCRIPTION
Fix [intel/webml-polyfill#1167](https://github.com/intel/webml-polyfill/issues/1167)

Since this file(https://github.com/cuiyanx/dnnl-models/blob/master/select-CTS-test/AVERAGE_POOL_2D/V1_3/avg_pool_quant8_signed.js) don't  contain any test case which has zero_pointer = 0, I run the available cts test of other files.

- Pass cts test:

1. https://github.com/cuiyanx/dnnl-models/blob/master/select-CTS-test/AVERAGE_POOL_2D/V1_0/avg_pool_quant8_1.js
2. https://github.com/cuiyanx/dnnl-models/blob/master/select-CTS-test/AVERAGE_POOL_2D/V1_0/avg_pool_quant8_2.js
3. Avg pool v1_2 example-20

- Regression test results:

   https://brucedai.github.io/webnnt/test/index-local.html?prefer=fast
   passes: 436 failures: 462(baseline: "pass": 436, "fail": 462)