### PR TITLE
[DNNL]Fix an issue of set dnnl_prop_kind_t

### DIFF
--- a/services/ml/compilation_delegate_dnnl.cc
+++ b/services/ml/compilation_delegate_dnnl.cc
@@ -585,8 +585,8 @@ int32_t CompilationDelegateDnnl::AddActivation(const std::string& input_name,
     return mojom::BAD_DATA;
   }
 
-  status = LATE(dnnl_eltwise_forward_desc_init)(&activation_desc, dnnl_forward,
-                                                alg_kind, input_md, alpha, 0.0);
+  status = LATE(dnnl_eltwise_forward_desc_init)(
+      &activation_desc, dnnl_forward_inference, alg_kind, input_md, alpha, 0.0);
   if (status != dnnl_success) {
     LOG(ERROR) << "[DNNL] failed to init eltwise descriptor " << status;
     return mojom::OP_FAILED;
@@ -1211,8 +1211,8 @@ int32_t CompilationDelegateDnnl::AddPooling(
   dnnl_dim_t pad_left[2] = {params.padding_top, params.padding_left};
   dnnl_dim_t pad_right[2] = {params.padding_bottom, params.padding_right};
   status = LATE(dnnl_pooling_forward_desc_init)(
-      &pool_desc, dnnl_forward, pooling_kind, input_pd, &output_md, strides,
-      kernel, pad_left, pad_right);
+      &pool_desc, dnnl_forward_inference, pooling_kind, input_pd, &output_md,
+      strides, kernel, pad_left, pad_right);
   if (status != mojom::NOT_ERROR) {
     LOG(ERROR) << "[DNNL] failed to init pooling descriptor " << status;
     return mojom::OP_FAILED;
@@ -1317,8 +1317,8 @@ int32_t CompilationDelegateDnnl::AddSoftmax(
   }
 
   dnnl_softmax_desc_t softmax_desc;
-  status = LATE(dnnl_softmax_forward_desc_init)(&softmax_desc, dnnl_forward,
-                                                input_md, input_md->ndims - 1);
+  status = LATE(dnnl_softmax_forward_desc_init)(
+      &softmax_desc, dnnl_forward_inference, input_md, input_md->ndims - 1);
   if (status != mojom::NOT_ERROR) {
     LOG(ERROR) << "[DNNL] failed to init softmax descriptor " << status;
     return mojom::OP_FAILED;
@@ -1587,8 +1587,8 @@ int32_t CompilationDelegateDnnl::AddFullyConnected(
 
   dnnl_inner_product_desc_t ip_desc;
   status = LATE(dnnl_inner_product_forward_desc_init)(
-      &ip_desc, dnnl_forward, &ip_input_desc, &weights_desc, &bias_desc,
-      &output_desc);
+      &ip_desc, dnnl_forward_inference, &ip_input_desc, &weights_desc,
+      &bias_desc, &output_desc);
   if (status != dnnl_success) {
     LOG(ERROR) << "[DNNL] failed to init inner product descriptor " << status;
     return mojom::OP_FAILED;


### PR DESCRIPTION
As [dnnl_prop_kind_t](https://oneapi-src.github.io/oneDNN/group__dnnl__api__primitives__common.html#ggae3c1f22ae55645782923fbfd8b07d0c4a2f77a568a675dec649eb0450c997856d) define, it should be set to `dnnl_forward_inference` instead of `dnnl_forward`. 
