### PR TITLE
[IENN-NGRAPH] Support VPU_MYRIAD Plugin

### DIFF
--- a/third_party/ienn/src/ie_compilation.cpp
+++ b/third_party/ienn/src/ie_compilation.cpp
@@ -170,8 +170,11 @@ int32_t Compilation::AddInput(uint32_t index) {
     return result;
   }
   try {
-    auto input_node =
-        std::make_shared<op::Parameter>(element::f32, Shape(dims));
+    // MYRIAD only supports FP16 models, but it can accept FP32 inputs. So we
+    // can also set the inputs precison to FP32.
+    auto input_node = std::make_shared<op::Parameter>(
+        preference_ != PREFER_LOW_POWER ? element::f32 : element::f16,
+        Shape(dims));
     index_op_map_[index] = input_node->output(0);
     ngraph_inputs_.push_back(input_node);
   } catch (const std::exception& ex) {
@@ -241,7 +244,7 @@ int32_t Compilation::AddConstant(uint32_t index,
         return result;
       }
       constant_node = std::make_shared<op::Constant>(
-          element::i16, Shape(const_dims), blob->buffer().as<int16_t*>());
+          element::f16, Shape(const_dims), blob->buffer().as<int16_t*>());
     }
     index_op_map_[index] = constant_node->output(0);
   } catch (const std::exception& ex) {

--- a/third_party/ienn/src/ie_execution.cpp
+++ b/third_party/ienn/src/ie_execution.cpp
@@ -21,7 +21,6 @@ static std::unique_ptr<InferRequest> s_gna_infer_request = nullptr;
 Execution::Execution(std::unique_ptr<Compilation> compilation)
     : compilation_(std::move(compilation)),
       infer_request_(nullptr),
-      plugin_(nullptr),
       execution_(nullptr),
       ie_core_(nullptr) {}
 
@@ -97,7 +96,7 @@ Execution::~Execution() {
     // Release in squence to avoid crash.
     infer_request_.reset(nullptr);
     execution_.reset(nullptr);
-    plugin_.reset(nullptr);
+    ie_core_.reset(nullptr);
   }
 }
 

--- a/third_party/ienn/src/ie_execution.h
+++ b/third_party/ienn/src/ie_execution.h
@@ -31,7 +31,6 @@ class Execution {
   std::vector<OutputData> output_data_;
 
   std::unique_ptr<InferRequest> infer_request_;
-  std::unique_ptr<InferencePlugin> plugin_;
   std::unique_ptr<ExecutableNetwork> execution_;
   std::unique_ptr<Core> ie_core_;
 


### PR DESCRIPTION
Please help to review, thanks! @fujunwei @lisa0314 
`Plugin` is removed in openVINO 2020.3, use `InferenceEngine::Core` instead, so delete it.