### PR TITLE
[IENN-NGRAPH] Resolve compilation errors on Windows

### DIFF
--- a/third_party/ienn/src/ie_compilation.h
+++ b/third_party/ienn/src/ie_compilation.h
@@ -19,6 +19,7 @@
 namespace ngraph {
 class Function;
 class Node;
+template <>
 class Output<ngraph::Node>;
 namespace op {
 namespace v0 {


### PR DESCRIPTION
There are some errors when building for Windows. I add the code to fix them. Then I succeed to build both for Linux and Windows. PTAL, thanks! @fujunwei @lisa0314 